### PR TITLE
feat(phase0): add TypeScript type definitions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,142 @@
+// Core Recipe types
+export interface Recipe {
+  id: string;
+  recipeName: string;
+  instructions: string;
+  prepTime: string;
+  cookTime: string;
+  servings: string;
+  imageUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Ingredient {
+  id: string;
+  name: string;
+  inPantry: boolean;
+  needToBuy: boolean;
+  updatedAt: string;
+}
+
+export interface RecipeIngredient {
+  id: string;
+  recipeId: string;
+  ingredientId: string;
+  quantity: string;
+  notes?: string;
+}
+
+export interface GroceryList {
+  id: string;
+  name: string;
+  status: 'Active' | 'Completed' | 'Archived';
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GroceryListItem {
+  id: string;
+  groceryListId: string;
+  ingredientId: string;
+  isPurchased: boolean;
+  quantity?: string;
+  notes?: string;
+}
+
+// API Request/Response types
+export interface ParseRecipeRequest {
+  recipeText: string;
+  language?: string;
+}
+
+export interface ParseRecipeResponse {
+  recipeName: string;
+  instructions: string;
+  prepTime: string;
+  cookTime: string;
+  servings: string;
+  ingredients: Array<{
+    name: string;
+    quantity: string;
+    notes?: string;
+  }>;
+}
+
+export interface CreateRecipeRequest {
+  recipeName: string;
+  instructions: string;
+  prepTime?: string;
+  cookTime?: string;
+  servings?: string;
+  imageUrl?: string;
+  ingredients: Array<{
+    name: string;
+    quantity: string;
+    notes?: string;
+  }>;
+}
+
+export interface UpdateRecipeRequest {
+  recipeName?: string;
+  instructions?: string;
+  prepTime?: string;
+  cookTime?: string;
+  servings?: string;
+  imageUrl?: string;
+}
+
+export interface CreateGroceryListRequest {
+  name: string;
+  notes?: string;
+  ingredientIds?: string[];
+}
+
+export interface UpdateGroceryListRequest {
+  name?: string;
+  status?: 'Active' | 'Completed' | 'Archived';
+  notes?: string;
+}
+
+export interface AddGroceryListItemRequest {
+  ingredientId: string;
+  quantity?: string;
+  notes?: string;
+}
+
+// Extended types with related data (for UI display)
+export interface RecipeWithIngredients extends Recipe {
+  ingredients: Array<RecipeIngredient & { ingredient: Ingredient }>;
+}
+
+export interface GroceryListWithItems extends GroceryList {
+  items: Array<GroceryListItem & { ingredient: Ingredient }>;
+}
+
+// Navigation types
+export type RootStackParamList = {
+  Recipes: undefined;
+  RecipesList: undefined;
+  RecipeDetail: { recipeId: string };
+  AddRecipe: undefined;
+  GroceryLists: undefined;
+  GroceryListDetail: { listId: string };
+  CreateGroceryList: undefined;
+  Shopping: undefined;
+  ShoppingList: undefined;
+  Auth: undefined;
+};
+
+// Auth types
+export interface User {
+  id: string;
+  email: string;
+  createdAt: string;
+}
+
+export interface AuthSession {
+  user: User;
+  accessToken: string;
+  refreshToken: string;
+}


### PR DESCRIPTION
Implements Phase 0 - TypeScript Types from web app adaptation.

- Create src/types/index.ts with all core interfaces
- Define Recipe, Ingredient, RecipeIngredient types
- Define GroceryList and GroceryListItem types
- Add API request/response types for parsing and CRUD operations
- Add extended types for UI display (RecipeWithIngredients, etc.)
- Add navigation types (RootStackParamList)
- Add auth types (User, AuthSession)

All types align with Supabase database schema and are compatible with React Native mobile app architecture.

Resolves dianadragoi35/InstaDishMobile#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)